### PR TITLE
refactor: ♻️ (github/release) 不要なchangelog.exclude.authorsを削除

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,8 +2,6 @@ changelog:
   exclude:
     labels:
       - 🤖renovate
-    authors:
-      - renovate-bot
   categories:
     - title: Some critical issues have been resolved! 🚑
       labels:


### PR DESCRIPTION
締まらないですがこのままにしとくのも気持ち悪いので...。

## Related Issues

- close #258 