### PR TITLE
fix: 🚑️ User.idに指定したidを格納できない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/graphql-validation-complexity": "0.4.0",
     "@types/jest": "29.1.2",
     "@types/node": "18.7.18",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "5.40.0",
     "@typescript-eslint/parser": "5.40.0",
     "apollo-server-express": "3.10.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "graphql-tag": "2.12.6",
     "graphql-validation-complexity": "0.4.2",
     "supertest-graphql": "1.1.4",
-    "ts-pattern": "4.0.5"
+    "ts-pattern": "4.0.5",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@apollo/rover": "0.9.1",

--- a/src/infra/prisma/generated/user/user-create-many/input.ts
+++ b/src/infra/prisma/generated/user/user-create-many/input.ts
@@ -7,8 +7,8 @@ import { Game } from '../../prisma/game/enum';
 @InputType()
 export class UserCreateManyInput {
 
-    @Field(() => String, {nullable:true})
-    id?: string;
+    @Field(() => String, {nullable:false})
+    id!: string;
 
     @Field(() => String, {nullable:false})
     name!: string;

--- a/src/infra/prisma/generated/user/user-create-without-character-statuses/input.ts
+++ b/src/infra/prisma/generated/user/user-create-without-character-statuses/input.ts
@@ -8,8 +8,8 @@ import { GiftHistoryCreateNestedManyWithoutUserInput } from '../../gift-history/
 @InputType()
 export class UserCreateWithoutCharacterStatusesInput {
 
-    @Field(() => String, {nullable:true})
-    id?: string;
+    @Field(() => String, {nullable:false})
+    id!: string;
 
     @Field(() => String, {nullable:false})
     name!: string;

--- a/src/infra/prisma/generated/user/user-create-without-gift-histories/input.ts
+++ b/src/infra/prisma/generated/user/user-create-without-gift-histories/input.ts
@@ -8,8 +8,8 @@ import { CharacterStatusCreateNestedManyWithoutUserInput } from '../../character
 @InputType()
 export class UserCreateWithoutGiftHistoriesInput {
 
-    @Field(() => String, {nullable:true})
-    id?: string;
+    @Field(() => String, {nullable:false})
+    id!: string;
 
     @Field(() => String, {nullable:false})
     name!: string;

--- a/src/infra/prisma/generated/user/user-create/input.ts
+++ b/src/infra/prisma/generated/user/user-create/input.ts
@@ -9,8 +9,8 @@ import { GiftHistoryCreateNestedManyWithoutUserInput } from '../../gift-history/
 @InputType()
 export class UserCreateInput {
 
-    @Field(() => String, {nullable:true})
-    id?: string;
+    @Field(() => String, {nullable:false})
+    id!: string;
 
     @Field(() => String, {nullable:false})
     name!: string;

--- a/src/infra/prisma/generated/user/user-unchecked-create-without-character-statuses/input.ts
+++ b/src/infra/prisma/generated/user/user-unchecked-create-without-character-statuses/input.ts
@@ -8,8 +8,8 @@ import { GiftHistoryUncheckedCreateNestedManyWithoutUserInput } from '../../gift
 @InputType()
 export class UserUncheckedCreateWithoutCharacterStatusesInput {
 
-    @Field(() => String, {nullable:true})
-    id?: string;
+    @Field(() => String, {nullable:false})
+    id!: string;
 
     @Field(() => String, {nullable:false})
     name!: string;

--- a/src/infra/prisma/generated/user/user-unchecked-create-without-gift-histories/input.ts
+++ b/src/infra/prisma/generated/user/user-unchecked-create-without-gift-histories/input.ts
@@ -8,8 +8,8 @@ import { CharacterStatusUncheckedCreateNestedManyWithoutUserInput } from '../../
 @InputType()
 export class UserUncheckedCreateWithoutGiftHistoriesInput {
 
-    @Field(() => String, {nullable:true})
-    id?: string;
+    @Field(() => String, {nullable:false})
+    id!: string;
 
     @Field(() => String, {nullable:false})
     name!: string;

--- a/src/infra/prisma/generated/user/user-unchecked-create/input.ts
+++ b/src/infra/prisma/generated/user/user-unchecked-create/input.ts
@@ -9,8 +9,8 @@ import { GiftHistoryUncheckedCreateNestedManyWithoutUserInput } from '../../gift
 @InputType()
 export class UserUncheckedCreateInput {
 
-    @Field(() => String, {nullable:true})
-    id?: string;
+    @Field(() => String, {nullable:false})
+    id!: string;
 
     @Field(() => String, {nullable:false})
     name!: string;

--- a/src/infra/prisma/schema.prisma
+++ b/src/infra/prisma/schema.prisma
@@ -42,7 +42,7 @@ enum Game {
 }
 
 model User {
-  id    String @id @default(auto()) @map("_id") @db.ObjectId
+  id    String @id @map("_id")
   name  String @unique
   email String
   role  Role   @default(USER)

--- a/src/infra/prisma/schema.prisma
+++ b/src/infra/prisma/schema.prisma
@@ -42,7 +42,7 @@ enum Game {
 }
 
 model User {
-  id    String @id @map("_id")
+  id    String @id @map("_id") @db.ObjectId
   name  String @unique
   email String
   role  Role   @default(USER)

--- a/src/infra/prisma/seed/seeder/user.seeder.ts
+++ b/src/infra/prisma/seed/seeder/user.seeder.ts
@@ -9,7 +9,7 @@ export class UserSeeder {
       Array.from<never, ReturnType<PrismaClient['user']['create']>>({ length: 30 }, (_, index) =>
         this.prisma.user.create({
           data: {
-            id: uuid().replace(/-/g, ''),
+            id: uuid().replace(/-/g, '').slice(0, 24),
             name: `user-${index < 10 ? `0${index}` : index}`,
             email: `user-${index < 10 ? `0${index}` : index}@example.com`,
           },

--- a/src/infra/prisma/seed/seeder/user.seeder.ts
+++ b/src/infra/prisma/seed/seeder/user.seeder.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { v4 as uuid } from 'uuid';
 
 export class UserSeeder {
   constructor(private readonly prisma: PrismaClient) {}
@@ -8,6 +9,7 @@ export class UserSeeder {
       Array.from<never, ReturnType<PrismaClient['user']['create']>>({ length: 30 }, (_, index) =>
         this.prisma.user.create({
           data: {
+            id: uuid(),
             name: `user-${index < 10 ? `0${index}` : index}`,
             email: `user-${index < 10 ? `0${index}` : index}@example.com`,
           },

--- a/src/infra/prisma/seed/seeder/user.seeder.ts
+++ b/src/infra/prisma/seed/seeder/user.seeder.ts
@@ -9,7 +9,7 @@ export class UserSeeder {
       Array.from<never, ReturnType<PrismaClient['user']['create']>>({ length: 30 }, (_, index) =>
         this.prisma.user.create({
           data: {
-            id: uuid(),
+            id: uuid().replace(/-/g, ''),
             name: `user-${index < 10 ? `0${index}` : index}`,
             email: `user-${index < 10 ? `0${index}` : index}@example.com`,
           },

--- a/src/module/user/repository/user.repository.spec.ts
+++ b/src/module/user/repository/user.repository.spec.ts
@@ -15,7 +15,7 @@ jest.setTimeout(15000);
 export const createUser = async (prismaService: PrismaService) => {
   const createdUser = await prismaService.user.create({
     data: {
-      id: uuid(),
+      id: uuid().replace(/-/g, ''),
       name: 'test user',
       email: 'test@example.com',
     },

--- a/src/module/user/repository/user.repository.spec.ts
+++ b/src/module/user/repository/user.repository.spec.ts
@@ -15,7 +15,7 @@ jest.setTimeout(15000);
 export const createUser = async (prismaService: PrismaService) => {
   const createdUser = await prismaService.user.create({
     data: {
-      id: uuid().replace(/-/g, ''),
+      id: uuid().replace(/-/g, '').slice(0, 24),
       name: 'test user',
       email: 'test@example.com',
     },
@@ -68,7 +68,7 @@ describe('UserRepository', () => {
   test('create', async () => {
     const createdUser = await userRepository.create({
       data: {
-        id: uuid(),
+        id: uuid().replace(/-/g, '').slice(0, 24),
         name: 'test user',
         email: 'test@example.com',
       },

--- a/src/module/user/repository/user.repository.spec.ts
+++ b/src/module/user/repository/user.repository.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
 import dotenv from 'dotenv';
+import { v4 as uuid } from 'uuid';
 import { User } from '../domain/model/user.model';
 import { UserRepository } from './user.repository';
 import { PrismaService } from '@/infra/prisma/prisma.service';
@@ -14,6 +15,7 @@ jest.setTimeout(15000);
 export const createUser = async (prismaService: PrismaService) => {
   const createdUser = await prismaService.user.create({
     data: {
+      id: uuid(),
       name: 'test user',
       email: 'test@example.com',
     },
@@ -66,6 +68,7 @@ describe('UserRepository', () => {
   test('create', async () => {
     const createdUser = await userRepository.create({
       data: {
+        id: uuid(),
         name: 'test user',
         email: 'test@example.com',
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,6 +1956,11 @@
   dependencies:
     "@types/superagent" "*"
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"


### PR DESCRIPTION
MongoDBでは`_id`の自動生成が有効になっているとき、外部から指定した文字列を`_id`として格納することはできないようです。
そのため`User.id`に限り`_id`のDB側での自動生成を廃止しました。
しかし、テスト時に`_id`を一々指定するのはテスタビリティに欠けるため、`uuid v4`によりコード側での自動生成を行っています。
~~ただし、この`uuid v4`が生成する文字列は(恐らく)現在時刻に依存しているため、極めて同時刻に近い並列処理ではその一意性は保証されません(経験済)。~~
~~ということで、この解決策はちょい脆弱性を孕んだ応急処置となっています。~~

~~ちなみにこの解決策はわかりません。~~

あ、これ嘘かも。
詳細は闇での中です。

p.s.
uuidくん規格で30数桁と定められているので、それを12byteぴったりに`slice()`しています。
本当はMongoDBの`_id`自動生成機構をOSS化したものを使えればベストでしたが、探しても見つからなかったのでしゃーなしです。

## Related Issues

- close #287 